### PR TITLE
Adds support for rendering nested z-objects

### DIFF
--- a/lib/zuora/soap.rb
+++ b/lib/zuora/soap.rb
@@ -4,3 +4,4 @@ module Zuora
 end
 
 require_relative 'soap/client'
+require_relative 'soap/z_object'

--- a/lib/zuora/soap/z_object.rb
+++ b/lib/zuora/soap/z_object.rb
@@ -1,0 +1,18 @@
+module Zuora
+  module Soap
+    class ZObject
+      extend Forwardable
+
+      attr_reader :type, :fields
+
+      # @params [Symbol] - name of ZObject
+      # @params [Hash] - a hash of fields
+      def initialize(type, fields)
+        @type = type
+        @fields = fields
+      end
+
+      def_delegators :@fields, :each, :map, :reduce, :inspect, :to_i
+    end
+  end
+end

--- a/spec/utils/envelope_spec.rb
+++ b/spec/utils/envelope_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'active_support/core_ext/hash/conversions'
+
+describe Zuora::Utils::Envelope do
+  let(:builder) { Nokogiri::XML::Builder.new }
+
+  describe 'nested recursive zobjects' do
+    let(:rate_plan_data) do
+      [
+        {
+          id: '123',
+          charge_model: 'DiscountPercentage',
+          product_rate_plan_charge_tier_data:
+            Zuora::Soap::ZObject.new(
+              :product_rate_plan_charge_tier,
+              discount_percentage: 22.22,
+              id: '123'
+            )
+        }
+      ]
+    end
+
+    let(:generated_xml) do
+      builder.update(Zuora::NAMESPACES) do |builder|
+        Zuora::Utils::Envelope.build_objects(
+          builder,
+          :ProductRatePlanCharge,
+          rate_plan_data
+        )
+      end
+      builder.to_xml
+    end
+
+    let(:parsed_xml) { Nokogiri::XML(generated_xml) }
+
+    xpath_selectors = %w(
+      //obj:ProductRatePlanChargeTierData/api:ProductRatePlanChargeTier
+      //api:ProductRatePlanChargeTier/obj:DiscountPercentage
+      //api:ProductRatePlanChargeTier/obj:Id
+    )
+
+    xpath_selectors.each do |selector|
+      it "selector is not empty: \n #{selector}" do
+        expect(parsed_xml.xpath(selector)).to_not be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
--
**UAT/QA Checklist**
@env removed

**Developer Checklist**
- [ ] I considered alternative approaches and chose the simplest one.
- [ ] I wrote unit/acceptance specs for these changes that test all possible conditions (success, failure, bad input, etc).
- [ ] I wrote unit/acceptance specs for code/functionality these changes may have affected.
- [ ] I can't think of any other code/functionality this may have affected that I didn't test or account for.
- [ ] I've ensured any necessary data migrations have been run.
- [ ] I've ensured other blocking code has been deployed (e.g. if part of a larger feature).
- [ ] We are able to track any changes to application performance or utilization introduced by this PR.

**Deploying is blocked by:**
- [ ] Nothing :shipit: