### PR TITLE
Add a GenericError class to group all zuora-ruby related Exception classes

### DIFF
--- a/lib/zuora/errors.rb
+++ b/lib/zuora/errors.rb
@@ -1,6 +1,8 @@
 module Zuora
   module Errors
-    class InvalidValue < StandardError
+    GenericError = Class.new(StandardError)
+
+    class InvalidValue < GenericError
       attr_reader :response
 
       def initialize(msg = nil, response = nil)
@@ -9,10 +11,10 @@ module Zuora
       end
     end
 
-    class InvalidCredentials < StandardError
+    class InvalidCredentials < GenericError
     end
 
-    class SoapConnectionError < StandardError
+    class SoapConnectionError < GenericError
     end
   end
 end

--- a/lib/zuora/rest.rb
+++ b/lib/zuora/rest.rb
@@ -4,10 +4,10 @@ module Zuora
     SANDBOX_URL = 'https://apisandbox-api.zuora.com/rest/v1/'.freeze
 
     # Unable to connect. Check username / password
-    ConnectionError = Class.new StandardError
+    ConnectionError = Class.new Errors::GenericError
 
     # Non-success response
-    class ErrorResponse < StandardError
+    class ErrorResponse < Errors::GenericError
       attr_reader :response
 
       def initialize(message = nil, response = nil)


### PR DESCRIPTION
Targets #57.

Adds a `Zuora::Errors::GenericError` class from which all zuora-related exception classes inherit. This allows in client code to target all exceptions at once with `rescue Zuora::Errors::GenericError` instead of targeting manually all possible exceptions (which may lead to problems when the gem gets updated with new, moved or deleted exceptions).